### PR TITLE
[Trading] Update gold color on Trading UI

### DIFF
--- a/Assets/Scripts/Systems/Trading/TradingUI/TradingUI.cs
+++ b/Assets/Scripts/Systems/Trading/TradingUI/TradingUI.cs
@@ -251,6 +251,7 @@ namespace Trading
                 tmp.enableAutoSizing = true;
                 tmp.alignment = TextAlignmentOptions.Right;
                 tmp.raycastTarget = false;
+                tmp.color = Color.black;
 
                 playerGoldText = tmp;
                 if (logMissingRefs) Debug.Log("[TradingUI] Created top-right Gold label.");


### PR DESCRIPTION
## What this PR does
Update the gold color on the trade UI to be black instead of white. Can be moved wherever we thought.
## Checklist
- [ ] Linked Trello card
- [ ] Tested locally (scene X)
- [ ] No debug logs left

## Reviewer Notes
- Anything special the reviewer should check?
